### PR TITLE
Allow Storage Policy RF to be configured

### DIFF
--- a/group_vars/cloudian.yml
+++ b/group_vars/cloudian.yml
@@ -2,8 +2,8 @@
 
 ansible_user: root
 ansible_ssh_pass: password
-s3_endpoint: https://s3-eu-1.demo4.cloudian.eu
-admin_endpoint: https://localhost:19443
+s3_endpoint: http://s3-region.example.com
+admin_endpoint: https://s3-admin.example.com:19443
 admin_username: sysadmin
 admin_password: public
 hyperstore_installer_node: "{{ ansible_play_hosts | intersect(groups['installer-node']) | first }}"

--- a/inventory/topology
+++ b/inventory/topology
@@ -3,10 +3,11 @@
 # Main host list. Either:
 # - set these manually OR
 # - Leave empty and use another, dynamic inventory combined with this topology inventory file
-# For S3 and S3-Admin calls only a single node is required
+# For S3 and S3-Admin calls only a single node is required, localhost will typically do as
+# long as it can reach the S3 and Admin endpoints configured in group_vars/cloudian.
 
 [cloudian]
-cloudian-node1 ansible_host=10.254.254.101
+cloudian-node1 ansible_host=127.0.0.1
 
 [installer-node]
 cloudian-node1

--- a/provision-all.yml
+++ b/provision-all.yml
@@ -29,6 +29,7 @@
 
     storage_policies:
       rf_3:
+        rf: 3
         default: True
 
   roles:

--- a/provision-policy.yml
+++ b/provision-policy.yml
@@ -11,6 +11,7 @@
 
     storage_policies:
       rf_3:
+        rf: 3
         default: True
 
   roles:

--- a/roles/policy/templates/policy.j2
+++ b/roles/policy/templates/policy.j2
@@ -27,14 +27,14 @@
     "encryptionEnabled": false,
     "encryptionType": "NONE",
     "groups": [],
-    "policyDescription": "Replication Factor 3 QUORUM",
+    "policyDescription": "Replication Factor {{ [ item.value.rf, 6 ] | min }} QUORUM",
     "policyId": "",
     "policyName": "{{ item.key }}",
     "region": "{{ cluster.region }}",
     "replicationScheme": {
-        "DC1": "3"
+        "DC1": "{{ [ item.value.rf, 6 ] | min }}"
     },
     "sizeThreshold": 0,
     "status": "ACTIVE",
-    "systemDefault": {{ item.value.default }}
+    "systemDefault": {{ item.value.default | default('False') }}
 }


### PR DESCRIPTION
Allow Policy RF to be specified. Also updated some default values to be more in line with both running Ansible on a remote node where it connects to the endpoint APIs, as when running Ansible on HyperStore node directly.